### PR TITLE
Upgrade to net9.0, Tests adopt HostedTestBase

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <TargetFrameworkVersion>net8.0</TargetFrameworkVersion>
+        <TargetFrameworkVersion>net9.0</TargetFrameworkVersion>
         <LangVersion>preview</LangVersion>
         <!-- <RunSettingsFilePath>$(SolutionDir)\.runsettings</RunSettingsFilePath> -->
         <ImplicitUsings>enable</ImplicitUsings>

--- a/Donjon.Test/Donjon.Test.csproj
+++ b/Donjon.Test/Donjon.Test.csproj
@@ -8,12 +8,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="nsubstitute" Version="5.1.0" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference> 
   </ItemGroup>
 
   <ItemGroup>

--- a/Donjon.Test/EntrypointTest.cs
+++ b/Donjon.Test/EntrypointTest.cs
@@ -1,6 +1,8 @@
 
 using System.Text.Json;
 
+using Donjon.Test.Utilities;
+
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -9,9 +11,13 @@ using Xunit.Abstractions;
 namespace Donjon.Test;
 
 public class EntrypointTest(ITestOutputHelper outputHelper)
+: HostedTestBase<EntrypointTest>(outputHelper)
 {
-    readonly XunitLogger<DungeonGen> _xunitLogger = new(outputHelper, LogLevel.Information);
-    readonly JsonSerializerOptions jsonOptions = new() { WriteIndented = true, MaxDepth = 20 };
+    readonly JsonSerializerOptions jsonOptions = new()
+    {
+        WriteIndented = true,
+        MaxDepth = 20
+    };
 
     public static IEnumerable<object[]> SplitCountData() { yield break; }
 
@@ -23,17 +29,17 @@ public class EntrypointTest(ITestOutputHelper outputHelper)
     [InlineData("surviving entry/doorway2nothing", 35, 15)]//   seed:35 39x39 csz=18 dunNone corBent nrooms:13 actual:13 last='13' sz(3..9) (surviving Entry)
     public void SpecificSeeds(string concern, int seed, int expectedDoorCount = -1)
     {
-        var g = new DungeonGen(_xunitLogger);
+        var g = new DungeonGen(LoggerFactory.CreateLogger<DungeonGen>());
         Dungeon d = new() { seed = seed, };
         Assert.NotNull(d.cell);
         Assert.NotNull(d.random);
         Assert.Equal(d.n_rows, d.cell.GetLength(0));
         Assert.Equal(d.n_cols, d.cell.GetLength(1));
-        // _xunitLogger.LogInformation("{description}", g.DescribeDungeon(d));
+        // Logger.LogInformation("{description}", g.DescribeDungeon(d));
 
         d = g.Create_dungeon(d);
-        _xunitLogger.LogInformation("{description}", g.DescribeDungeonLite(d));
-        _xunitLogger.LogInformation("{description}", concern);
+        Logger.LogInformation("{description}", g.DescribeDungeonLite(d));
+        Logger.LogInformation("{description}", concern);
 
         // Then
         var indices = Enumerable.Range(0, d.cell.GetLength(0))
@@ -47,8 +53,8 @@ public class EntrypointTest(ITestOutputHelper outputHelper)
         int countDoorsByObject = d.door.Count;
         var indicesNotInObjs = doorIndices.Except(d.door.Select(door => door.Coord)).ToArray();
         var objsNotInIndices = d.door.Select(door => door.Coord).Except(doorIndices).ToArray();
-        _xunitLogger.LogInformation("{c} cells Notin= {a}",indicesNotInObjs.Count(),string.Join(",",indicesNotInObjs));
-        _xunitLogger.LogInformation("{c} objs Notin cells = {a}", objsNotInIndices.Count(),string.Join(",",objsNotInIndices));
+        Logger.LogInformation("{c} cells Notin= {a}", indicesNotInObjs.Count(), string.Join(",", indicesNotInObjs));
+        Logger.LogInformation("{c} objs Notin cells = {a}", objsNotInIndices.Count(), string.Join(",", objsNotInIndices));
 
         Assert.True(countDoorsByCell == countDoorsByObject, $"doors: {countDoorsByCell} cel != {countDoorsByObject} obj");
         Assert.Equal(expectedDoorCount, countDoorsByObject);
@@ -109,19 +115,19 @@ public class EntrypointTest(ITestOutputHelper outputHelper)
             Assert.NotNull(d.random);
             Assert.Equal(d.n_rows, d.cell.GetLength(0));
             Assert.Equal(d.n_cols, d.cell.GetLength(1));
-            _xunitLogger.LogInformation("{description}", g.DescribeDungeon(d));
+            Logger.LogInformation("{description}", g.DescribeDungeon(d));
             try
             {
                 var d2 = g.Create_dungeon(d);
-                _xunitLogger.LogInformation("{description}", g.DescribeDungeonLite(d2));
+                Logger.LogInformation("{description}", g.DescribeDungeonLite(d2));
             }
             catch (Exception exception)
             {
                 interestingOnes.Add(new { exception, seed, });
             }
         }
-        _xunitLogger.LogInformation("seeds tested: [{s}]", string.Join(",", seeds));
-        _xunitLogger.LogInformation(JsonSerializer.Serialize(interestingOnes, options: jsonOptions));
+        Logger.LogInformation("seeds tested: [{s}]", string.Join(",", seeds));
+        Logger.LogInformation(JsonSerializer.Serialize(interestingOnes, options: jsonOptions));
         Assert.Empty(interestingOnes);
     }
 
@@ -130,7 +136,6 @@ public class EntrypointTest(ITestOutputHelper outputHelper)
     public void RandomlyProbeDungeonSeeds_AlwaysLog()
     {
         RandomlyProbeDungeonSeeds();
-        Assert.Fail("ACTUALLY OK!");
     }
 
     [Fact(Skip = "manual confirmation")]
@@ -138,14 +143,13 @@ public class EntrypointTest(ITestOutputHelper outputHelper)
     {
         // Information[0]<HelloStringScope> info
         // Information[0]<{ hello = object, scope = 2 }>HelloStringScope> info2
-        using (_xunitLogger.BeginScope("HelloStringScope"))
+        using (Logger.BeginScope("HelloStringScope"))
         {
-            _xunitLogger.LogInformation("info");
-            using (_xunitLogger.BeginScope(new { hello = "object", scope = 2 }))
+            Logger.LogInformation("info");
+            using (Logger.BeginScope(new { hello = "object", scope = 2 }))
             {
-                _xunitLogger.LogInformation("info2");
+                Logger.LogInformation("info2");
             }
         }
-        Assert.Fail("Show Output");
     }
 }

--- a/Donjon.Test/Utilities/HostedTestBase.cs
+++ b/Donjon.Test/Utilities/HostedTestBase.cs
@@ -1,0 +1,96 @@
+// #define USE_REFLECTED_MOCK_LOGGER
+namespace Donjon.Test.Utilities;
+using NSubstitute;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+using Microsoft.Extensions.Hosting;
+using System.Diagnostics.CodeAnalysis;
+
+public class HostedTestBase<T> // where T : class
+{
+    protected IHost TestHost { get; private init; }
+    protected ILogger<T> Logger { get; private init; }
+    protected ILoggerFactory LoggerFactory { get; private set; }
+    protected ITestOutputHelper XunitOutput { get; }
+
+    [NotNullIfNotNull(nameof(TestHost))]
+    protected IServiceProvider Services => TestHost.Services;
+
+    public HostedTestBase(ITestOutputHelper output, LogLevel min = LogLevel.Information)
+    {
+        XunitOutput = output;
+
+        TestHost = Host.CreateDefaultBuilder()
+            .ConfigureLogging(b => PerformLoggingConfig(b, min))
+            .ConfigureServices(PerformServiceConfig)
+            .ConfigureHostOptions(PerformOptionsConfig)
+            .Build();
+
+        Logger = Services.GetRequiredService<ILogger<T>>();
+        LoggerFactory = Services.GetRequiredService<ILoggerFactory>();
+    }
+
+    ILoggerProvider MockProvider(LogLevel level)
+    {
+        ILoggerProvider toh = Substitute.For<ILoggerProvider>();
+#if USE_REFLECTED_MOCK_LOGGER
+            toh.CreateLogger(NSubstitute.Arg.Any<string>()).Returns(o =>
+                {
+                    string category = o.Arg<string>();
+                    var types = AppDomain.CurrentDomain.GetAssemblies()
+                        .SelectMany(asm => asm.GetTypes().Where(t => t.FullName == category));
+                    if (!types.Any()) { return new TestLogger<object>(output, parameters, category); }
+                    // FIXME: assignableTo/From [ms].[ext].[h].[in].ApplicationLifetime as [ms].[ext].[h].[in].IHostApplicationLifetime
+
+                    Type genericType = types.FirstOrDefault() // Type.GetType(o.Arg<string>())
+                        ?? throw new Exception($"Unable to prepare loggerprovider for '{o.Arg<string>()}'");
+
+                    Type genericClassType = typeof(TestLogger<>);
+
+
+                    // Make the generic type with the given type
+                    Type constructedType = genericClassType.MakeGenericType(genericType);
+
+                    // Create an instance of the constructed type
+                    object instance = Activator.CreateInstance(constructedType, output, parameters)
+                        ?? throw new Exception($"sww1");
+
+                    // Use reflection to access the Value property
+                    return instance;
+                    //?
+                    // constructedType.get
+
+                    // System.Reflection.PropertyInfo valueProperty = constructedType.GetProperty("Value")
+                    //     ?? throw new Exception($"sww2");
+                    // object value = valueProperty.GetValue(instance) ?? throw new Exception($"sww");
+
+                    // return value;
+                }
+                );
+#else
+        toh.CreateLogger(Arg.Any<string>())
+            .Returns(o => new XunitLogger<object>(XunitOutput, min: level, category: o.Arg<string>()));
+#endif
+        return toh;
+    }
+
+    private void PerformLoggingConfig(ILoggingBuilder context, LogLevel level)
+    {
+        context.ClearProviders().AddProvider(MockProvider(level));
+        ApplyFilters(context);
+    }
+
+    protected virtual Dictionary<LogLevel, IEnumerable<string>> Filters => [];
+
+    private void ApplyFilters(ILoggingBuilder context)
+    {
+        foreach (var f in Filters)
+            foreach (var category in f.Value)
+                context.AddFilter(category, level: f.Key);
+    }
+
+    // protected virtual IHostBuilder PerformHostConfig(IHostBuilder builder) => builder;
+    protected virtual void PerformOptionsConfig(HostBuilderContext context, HostOptions options) { }
+    protected virtual void PerformServiceConfig(HostBuilderContext context, IServiceCollection services) { }
+}

--- a/Donjon.Test/Utilities/XunitLogger.cs
+++ b/Donjon.Test/Utilities/XunitLogger.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 
 using Xunit.Abstractions;
+namespace Donjon.Test.Utilities;
 
 /// <summary>
 /// Logs to both testoutput and Debug
@@ -12,7 +13,7 @@ using Xunit.Abstractions;
 /// supports loglevel overrides by pushing loglevel as a scope
 /// </summary>
 /// <typeparam name="T"></typeparam>
-public class XunitLogger<T>(ITestOutputHelper output, LogLevel min = LogLevel.Information) : ILogger<T>
+public class XunitLogger<T>(ITestOutputHelper output, string? category = null, LogLevel min = LogLevel.Information) : ILogger<T>
 {
     readonly ConcurrentStack<object> _scopes = [];
     struct Ephemeral(XunitLogger<T> issuer) : IDisposable
@@ -35,7 +36,7 @@ public class XunitLogger<T>(ITestOutputHelper output, LogLevel min = LogLevel.In
     }
 
     public bool IsEnabled(LogLevel logLevel) => // logLevel >= min ||
-        // (logLevel >= ((_scopes.FirstOrDefault(s => s is LogLevel) as LogLevel?) ?? min))
+                                                // (logLevel >= ((_scopes.FirstOrDefault(s => s is LogLevel) as LogLevel?) ?? min))
         (logLevel >= (LogLevel)Math.Min((int)min, (int)((_scopes.FirstOrDefault(s => s is LogLevel) as LogLevel?) ?? min)))
         || (logLevel >= LogLevel.Debug && Debugger.IsAttached);
 

--- a/Donjon/Donjon.csproj
+++ b/Donjon/Donjon.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-    <PackageReference Include="Sixlabors.ImageSharp" Version="3.1.4" />
+    <PackageReference Include="microsoft.Extensions.Logging" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="9.0.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.10" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
1. Upgrade to net9.0
2. Tests adopt HostedTestBase, from which test classes can inherit an environment with dependency injection available